### PR TITLE
Switch links to User Page

### DIFF
--- a/src/components/Leaderboard.js
+++ b/src/components/Leaderboard.js
@@ -59,8 +59,10 @@ const LinkCell = (props) => {
   var {rowIndex, data, field, ...other} = props;
   if (!data[rowIndex]) return <Cell></Cell>;
 
-  var userid = props.data[rowIndex].user_id;
-  var userlink = 'http://missingmaps.org/users/#/' + userid;
+  var username = props.data[rowIndex].name;
+  var usernameShift = username.replace(/\s+/g, '-').toLowerCase();
+
+  var userlink = 'http://missingmaps.org/users/#/' + usernameShift;
   var userClass = data[rowIndex].team + '-name statsCell table-username';
 
   var display = data[rowIndex][field];


### PR DESCRIPTION
Changes the link from users in the leaderboard to use the username rather than the user id. Part of this [wider reaching PR](https://github.com/MissingMaps/users/pull/32). 

Merge in only when we're ready to go on all fronts.